### PR TITLE
Add CODEOWNERS file for repository ownership

### DIFF
--- a/.github/workflows/CODEOWNERS
+++ b/.github/workflows/CODEOWNERS
@@ -1,0 +1,4 @@
+# Syntax for this file at https://help.github.com/articles/about-codeowners/
+
+*       @conda/build-tools
+*       @conda/conda-maintainers

--- a/.github/workflows/CODEOWNERS
+++ b/.github/workflows/CODEOWNERS
@@ -1,4 +1,3 @@
 # Syntax for this file at https://help.github.com/articles/about-codeowners/
 
-*       @conda/build-tools
-*       @conda/conda-maintainers
+*       @conda/build-tools @conda/conda-maintainers


### PR DESCRIPTION
<!-- Hello! Thanks for submitting a PR! To help make things go a bit more
     smoothly, we would appreciate it if you follow this template. -->

### Description

This pull request updates the `.github/workflows/CODEOWNERS` file to assign ownership of all files to the `@conda/build-tools` and `@conda/conda-maintainers` teams.

<!-- Good things to put here include:
       - reasons for the change (please link any relevant issues!),
       - any noteworthy (or hacky) choices to be aware of,
       - or what the problem resolved here looked like. -->



<!-- Just as a reminder, everyone in all conda org spaces (including PRs)
     must follow the Conda Org Code of Conduct (link below).

     Finally, once again, thanks for your time and effort. If you have any
     feedback in regards to your experience contributing here, please
     let us know!

     Helpful links:
       - Conda Org COC: https://github.com/conda/.github/blob/main/CODE_OF_CONDUCT.md
       - Contributing docs: https://github.com/conda/.github/blob/main/CONTRIBUTING.md -->
