### PR TITLE
feat: add automated CI builds and releases with sigstore attestation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,117 @@
+name: Build Launchers
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_call:
+    outputs:
+      artifact-name:
+        description: "Name of the uploaded build artifact"
+        value: "conda-launchers-all"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  ZIG_VERSION: "0.13.0"
+
+jobs:
+  build:
+    name: Build ${{ matrix.exe_type }}-${{ matrix.arch }}
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x86, x86_64, aarch64]
+        exe_type: [cli, gui]
+        include:
+          - arch: x86
+            zig_target: x86-windows-gnu
+            suffix: "32"
+          - arch: x86_64
+            zig_target: x86_64-windows-gnu
+            suffix: "64"
+          - arch: aarch64
+            zig_target: aarch64-windows-gnu
+            suffix: "arm64"
+          - exe_type: cli
+            gui_flag: "false"
+          - exe_type: gui
+            gui_flag: "true"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup Zig
+        uses: mlugg/setup-zig@a84e2efe7f7bba42dc0a2e498e6e8e8e498467a5 # v2.0.1
+        with:
+          version: ${{ env.ZIG_VERSION }}
+
+      - name: Download and patch launcher source
+        shell: bash
+        run: |
+          curl -fsSL -o launcher.c \
+            "https://raw.githubusercontent.com/python/cpython/3.7/PC/launcher.c"
+          # Verify checksum
+          echo "a3167e5908cefa942f63e0de5c6ec7a929e8ca82a382537ab8292e5aaa82ca2e  launcher.c" | sha256sum -c -
+          # Apply the conda patch
+          patch -p0 < src/cpython-launcher-c-mods-for-setuptools.3.7.patch
+          # Move patched file into src/ so zig build can find it
+          mv launcher.c src/launcher.c
+
+      - name: Build ${{ matrix.exe_type }}-${{ matrix.suffix }}
+        shell: bash
+        working-directory: src
+        run: |
+          zig build \
+            -Doptimize=ReleaseSmall \
+            -Dtarget=${{ matrix.zig_target }} \
+            -Dgui=${{ matrix.gui_flag }}
+          ls -lh zig-out/bin/
+
+      - name: Rename artifact
+        shell: bash
+        run: |
+          mkdir -p artifacts
+          cp src/zig-out/bin/${{ matrix.exe_type }}-${{ matrix.suffix }}.exe \
+             artifacts/${{ matrix.exe_type }}-${{ matrix.suffix }}.exe
+
+      - name: Upload individual artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ${{ matrix.exe_type }}-${{ matrix.suffix }}
+          path: artifacts/${{ matrix.exe_type }}-${{ matrix.suffix }}.exe
+          if-no-files-found: error
+
+  collect:
+    name: Collect all launchers
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          path: all-launchers
+          pattern: "*"
+          merge-multiple: true
+
+      - name: Generate checksums
+        shell: bash
+        working-directory: all-launchers
+        run: |
+          sha256sum *.exe | tee SHA256SUMS.txt
+
+      - name: Upload combined artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: conda-launchers-all
+          path: all-launchers/
+          if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,122 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write        # create GitHub releases
+  id-token: write        # sigstore OIDC token
+  attestations: write    # GitHub artifact attestations
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # ── Step 1: Build all launchers via the reusable build workflow ─────────
+  build:
+    uses: ./.github/workflows/build.yml
+
+  # ── Step 2: Create GitHub Release with attestation & checksums ─────────
+  release:
+    name: Create GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Download all launcher artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: conda-launchers-all
+          path: release-assets/
+
+      - name: Display release assets
+        run: ls -lhR release-assets/
+
+      # ── Sigstore attestation for each binary ──────────────────────────
+      - name: Attest cli-32.exe
+        uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v2.1.0
+        with:
+          subject-path: release-assets/cli-32.exe
+
+      - name: Attest cli-64.exe
+        uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v2.1.0
+        with:
+          subject-path: release-assets/cli-64.exe
+
+      - name: Attest cli-arm64.exe
+        uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v2.1.0
+        with:
+          subject-path: release-assets/cli-arm64.exe
+
+      - name: Attest gui-32.exe
+        uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v2.1.0
+        with:
+          subject-path: release-assets/gui-32.exe
+
+      - name: Attest gui-64.exe
+        uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v2.1.0
+        with:
+          subject-path: release-assets/gui-64.exe
+
+      - name: Attest gui-arm64.exe
+        uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v2.1.0
+        with:
+          subject-path: release-assets/gui-arm64.exe
+
+      - name: Attest SHA256SUMS.txt
+        uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v2.1.0
+        with:
+          subject-path: release-assets/SHA256SUMS.txt
+
+      # ── Create the release ────────────────────────────────────────────
+      #  • Uses GitHub's immutable release tag feature (the tag is already
+      #    pushed, and we set make_latest + generate_release_notes).
+      #  • Uploads all .exe files + SHA256SUMS.txt as release assets.
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8bb048 # v2.2.0
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: "conda-launchers ${{ github.ref_name }}"
+          body: |
+            ## conda-launchers ${{ github.ref_name }}
+
+            Windows Python entry-point launchers for the conda ecosystem.
+
+            ### Included binaries
+
+            | File | Architecture | Type |
+            |------|-------------|------|
+            | `cli-32.exe` | x86 (32-bit) | Console |
+            | `cli-64.exe` | x86_64 (64-bit) | Console |
+            | `cli-arm64.exe` | aarch64 (ARM64) | Console |
+            | `gui-32.exe` | x86 (32-bit) | GUI (pythonw) |
+            | `gui-64.exe` | x86_64 (64-bit) | GUI (pythonw) |
+            | `gui-arm64.exe` | aarch64 (ARM64) | GUI (pythonw) |
+
+            ### Verification
+
+            Each binary has a [sigstore build provenance attestation](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds).
+            You can verify any binary with:
+
+            ```bash
+            gh attestation verify <file> --repo ${{ github.repository }}
+            ```
+
+            SHA256 checksums are available in `SHA256SUMS.txt`.
+          draft: false
+          prerelease: false
+          make_latest: true
+          generate_release_notes: true
+          files: |
+            release-assets/cli-32.exe
+            release-assets/cli-64.exe
+            release-assets/cli-arm64.exe
+            release-assets/gui-32.exe
+            release-assets/gui-64.exe
+            release-assets/gui-arm64.exe
+            release-assets/SHA256SUMS.txt

--- a/README.md
+++ b/README.md
@@ -28,6 +28,43 @@ In April 2024, the files were committed again after being `codesign`ed by Anacon
 
 This repository now collects all those sources and suggests a way to package them as a conda package for easy reutilization.
 
+## Automated builds & releases
+
+All launcher binaries are built automatically in GitHub Actions using Zig as a
+cross-compiler. Every push to `main` and every pull request triggers the
+**Build Launchers** workflow which produces:
+
+| Binary | Architecture | Type |
+|--------|-------------|------|
+| `cli-32.exe` | x86 (32-bit) | Console |
+| `cli-64.exe` | x86_64 (64-bit) | Console |
+| `cli-arm64.exe` | aarch64 (ARM64) | Console |
+| `gui-32.exe` | x86 (32-bit) | GUI |
+| `gui-64.exe` | x86_64 (64-bit) | GUI |
+| `gui-arm64.exe` | aarch64 (ARM64) | GUI |
+
+### Creating a release
+
+Push a semver tag to trigger the **Release** workflow:
+
+```bash
+git tag v24.7.2
+git push origin v24.7.2
+```
+
+The release workflow will:
+
+1. Build all six launcher binaries.
+2. Generate `SHA256SUMS.txt` checksums.
+3. Create [sigstore build-provenance attestations](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds) for every artifact.
+4. Publish an **immutable GitHub Release** with all assets attached.
+
+### Verifying attestations
+
+```bash
+gh attestation verify cli-arm64.exe --repo conda/conda-launchers
+```
+
 ## Debugging
 
 The launchers will provide some debugging information if the environment variable `PYLAUNCH_DEBUG=1` is set.


### PR DESCRIPTION
- Add build.yml: builds all 6 launcher binaries (cli/gui × 32/64/arm64) using Zig cross-compilation on every push and PR
- Add release.yml: on v* tag push, builds all binaries, generates SHA256 checksums, creates sigstore build-provenance attestations, and publishes an immutable GitHub Release
- Update README with automated build/release documentation

Addresses conda/rattler#476


