### PR TITLE
Fix release pipeline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Setup Pixi
         uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0 # v0.9.5
         with:
-          cache: true
+          cache: ${{ github.event_name == 'pull_request' }}
 
       - name: Pixi info
         run: |
@@ -119,7 +119,7 @@ jobs:
       - name: Setup Pixi
         uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0 # v0.9.5
         with:
-          cache: true
+          cache: false
 
       - name: Pixi info
         run: |
@@ -166,7 +166,7 @@ jobs:
       - name: Setup Pixi
         uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0 # v0.9.5
         with:
-          cache: true
+          cache: false
           environments: extract
 
       - name: Pixi info

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -146,6 +146,9 @@ jobs:
     if: github.event_name == 'release'
     env:
       PYTHONUNBUFFERED: "1"
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - name: Checkout Source
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,6 +1,6 @@
 context:
   version: "24.7.1"
-  build_number: 4
+  build_number: 5
   arch_suffix : ${{ target_platform | split ("-") | last }}
 
 recipe:


### PR DESCRIPTION
* Permissions were missing in the release creation job
* Also disabled pixi cache for release jobs to protect against [cache poisoning](https://cheatsheetseries.owasp.org/cheatsheets/GitHub_Actions_Security_Cheat_Sheet.html#prevent-artifact-poisoning)
* Bumped recipe build number to 5